### PR TITLE
Fix incorrect constructor for 'uint128_t' types

### DIFF
--- a/src/farmhash.cc
+++ b/src/farmhash.cc
@@ -1787,7 +1787,7 @@ STATIC_INLINE uint128_t CityMurmur(const char *s, size_t len, uint128_t seed) {
   }
   a = HashLen16(a, c);
   b = HashLen16(d, b);
-  return uint128_t(a ^ b, HashLen16(b, a));
+  return Uint128(a ^ b, HashLen16(b, a));
 }
 
 uint128_t CityHash128WithSeed(const char *s, size_t len, uint128_t seed) {
@@ -1849,15 +1849,15 @@ uint128_t CityHash128WithSeed(const char *s, size_t len, uint128_t seed) {
   // different 56-byte-to-8-byte hashes to get a 16-byte final result.
   x = HashLen16(x, v.first);
   y = HashLen16(y + z, w.first);
-  return uint128_t(HashLen16(x + v.second, w.second) + y,
-                   HashLen16(x + w.second, y + v.second));
+  return Uint128(HashLen16(x + v.second, w.second) + y,
+                 HashLen16(x + w.second, y + v.second));
 }
 
 STATIC_INLINE uint128_t CityHash128(const char *s, size_t len) {
   return len >= 16 ?
       CityHash128WithSeed(s + 16, len - 16,
-                          uint128_t(Fetch(s), Fetch(s + 8) + k0)) :
-      CityHash128WithSeed(s, len, uint128_t(k0, k1));
+                          Uint128(Fetch(s), Fetch(s + 8) + k0)) :
+      CityHash128WithSeed(s, len, Uint128(k0, k1));
 }
 
 uint128_t Fingerprint128(const char* s, size_t len) {

--- a/src/farmhash.h
+++ b/src/farmhash.h
@@ -56,6 +56,11 @@
 namespace NAMESPACE_FOR_HASH_FUNCTIONS {
 
 #if defined(FARMHASH_UINT128_T_DEFINED)
+#if defined(__clang__)
+#if !defined(uint128_t)
+#define uint128_t __uint128_t
+#endif
+#endif
 inline uint64_t Uint128Low64(const uint128_t x) {
   return static_cast<uint64_t>(x);
 }


### PR DESCRIPTION
Unlinke `GCC`, `clang` (up to and including `clang-3.7.0`) does **not** have a native `uint128_t` type. It _does_ have a native `__uint128_t` type, however.

However, when compiling with this on 64-bit targets, you must use

    -Duint128_t=__uint128_t -DFARMHASH_UINT128_T_DEFINED

when then shows that there are constructor typos in `farmhash.cc`. `GCC` allows two-parameter constructors for `uint128_t` types, but `clang` does not.

This trivial patch fixes this, and is likely what was originally intended.

For this patch, I've integrated the `-Duint128_t=__uint128_t` into the header, since that is what was also likely intended. Note that `uint128_t` is only defined if it is currently undefined.