### PR TITLE
Generate main() for running self-test.

### DIFF
--- a/dev/builder.cc
+++ b/dev/builder.cc
@@ -459,6 +459,14 @@ int main(int argc, char** argv) {
                   "done");
   DoWithNoOutputExpected("(echo; echo '#if FARMHASHSELFTEST'; echo;"
                          " cat " + dir + "/*_selftest1.cc;"
+                         " echo; echo 'int main() {';"
+                         " for i in " + dir + "/*_gen.cc; "
+                         " do"
+                         "   namespace=$(basename ${i%_gen.cc});"
+                         "   echo '  '${namespace}'Test::RunTest();';"
+                         " done;"
+                         " echo '  __builtin_unreachable();';"
+                         " echo '}';"
                          " echo; echo '#endif  // FARMHASHSELFTEST') "
                          ">> ../src/farmhash.cc");
 

--- a/dev/self-test-skeleton.cc
+++ b/dev/self-test-skeleton.cc
@@ -144,11 +144,7 @@ void Dump(int offset, int len) {
 
 }  // namespace SKELETON
 
-#if TESTING
-
-static int SKELETONResult = SKELETON::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";

--- a/src/farm-test.cc
+++ b/src/farm-test.cc
@@ -34,5 +34,3 @@
 #define FARMHASH_DIE_IF_MISCONFIGURED do { return 0; } while (0)
 
 #include "farmhash.cc"
-
-int main() {}

--- a/src/farmhash.cc
+++ b/src/farmhash.cc
@@ -3571,11 +3571,7 @@ cout << farmhashcc::Hash32(data + offset, len) << "u," << endl;
 
 }  // namespace farmhashccTest
 
-#if TESTING
-
-static int farmhashccTestResult = farmhashccTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -4467,11 +4463,7 @@ cout << farmhashmk::Hash32(data + offset, len) << "u," << endl;
 
 }  // namespace farmhashmkTest
 
-#if TESTING
-
-static int farmhashmkTestResult = farmhashmkTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -5727,11 +5719,7 @@ void Dump(int offset, int len) {
 
 }  // namespace farmhashnaTest
 
-#if TESTING
-
-static int farmhashnaTestResult = farmhashnaTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -6623,11 +6611,7 @@ cout << farmhashnt::Hash32(data + offset, len) << "u," << endl;
 
 }  // namespace farmhashntTest
 
-#if TESTING
-
-static int farmhashntTestResult = farmhashntTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -7519,11 +7503,7 @@ cout << farmhashsa::Hash32(data + offset, len) << "u," << endl;
 
 }  // namespace farmhashsaTest
 
-#if TESTING
-
-static int farmhashsaTestResult = farmhashsaTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -8415,11 +8395,7 @@ cout << farmhashsu::Hash32(data + offset, len) << "u," << endl;
 
 }  // namespace farmhashsuTest
 
-#if TESTING
-
-static int farmhashsuTestResult = farmhashsuTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -9675,11 +9651,7 @@ void Dump(int offset, int len) {
 
 }  // namespace farmhashteTest
 
-#if TESTING
-
-static int farmhashteTestResult = farmhashteTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -10571,11 +10543,7 @@ void Dump(int offset, int len) {
 
 }  // namespace farmhashuoTest
 
-#if TESTING
-
-static int farmhashuoTestResult = farmhashuoTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -11831,11 +11799,7 @@ void Dump(int offset, int len) {
 
 }  // namespace farmhashxoTest
 
-#if TESTING
-
-static int farmhashxoTestResult = farmhashxoTest::RunTest();
-
-#else
+#if !TESTING
 int main(int argc, char** argv) {
   Setup();
   cout << "uint32_t expected[] = {\n";
@@ -11850,5 +11814,18 @@ int main(int argc, char** argv) {
   cout << "};\n";
 }
 #endif
+
+int main() {
+  farmhashccTest::RunTest();
+  farmhashmkTest::RunTest();
+  farmhashnaTest::RunTest();
+  farmhashntTest::RunTest();
+  farmhashsaTest::RunTest();
+  farmhashsuTest::RunTest();
+  farmhashteTest::RunTest();
+  farmhashuoTest::RunTest();
+  farmhashxoTest::RunTest();
+  __builtin_unreachable();
+}
 
 #endif  // FARMHASHSELFTEST


### PR DESCRIPTION
Avoid running test from global constructor as (in skeleton code):

  (global scope)
  static int SKELETONResult = SKELETON::RunTest();

Executing complicated code in global constructors is quite dangerous. As
the order of global constructors being invoked between translation units
is unspecified, we may end up using things from dependent libraries that
haven't been initialized yet.

In our internal build environment, farmhash_unittest is linked against
static version of STL library (more specifically, libc++.a). Running it
gets segfault because RunTest()s access uninitialized `std::cout`.

This commit modifies builder.cc to generate main() in farmhash.cc which
calls RunTest()s for self-test code. There's no functionality changed.

Test plan: pass "make check".