### PR TITLE
Fix build for MinGW compiler

### DIFF
--- a/src/farmhash.cc
+++ b/src/farmhash.cc
@@ -114,7 +114,7 @@
 
 #if defined(FARMHASH_UNKNOWN_ENDIAN) || !defined(bswap_64)
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 #undef bswap_32
 #undef bswap_64
@@ -225,7 +225,7 @@ STATIC_INLINE uint64_t BasicRotate64(uint64_t val, int shift) {
   return shift == 0 ? val : ((val >> shift) | (val << (64 - shift)));
 }
 
-#if defined(_MSC_VER) && defined(FARMHASH_ROTR)
+#if defined(_WIN32) && defined(FARMHASH_ROTR)
 
 STATIC_INLINE uint32_t Rotate32(uint32_t val, int shift) {
   return sizeof(unsigned long) == sizeof(val) ?


### PR DESCRIPTION
Fixing compilation error with mingw compiler

```
farmhash.cc:181:10: fatal error: byteswap.h: No such file or directory
 #include <byteswap.h>
          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:618: farmhash.lo] Error 1
make[2]: Leaving directory '/c/dev/farmhash/src'
make[1]: *** [Makefile:462: all-recursive] Error 1
make[1]: Leaving directory '/c/dev/farmhash'
make: *** [Makefile:372: all] Error 2
```

This fix will make be possible to compile TensorFlow Lite with mingw compiler.

https://github.com/tensorflow/tensorflow/pull/26040#issuecomment-489428268