### PR TITLE
undef bitswap.h before including it

### DIFF
--- a/src/farmhash.cc
+++ b/src/farmhash.cc
@@ -178,6 +178,7 @@
 
 #undef bswap_32
 #undef bswap_64
+#undef _BYTESWAP_H
 #include <byteswap.h>
 
 #endif


### PR DESCRIPTION
In this #if branch, the code #undef's bswap_{32,64} and then includes
the header file byteswap.h which has definitions for these two macros.
However, if this header file was already included in the past, then the
inclusion gets skipped since byteswap.h has an #ifdef guard.

With this change, including byteswap.h always gets processed and defines
bswap_{32,64} again.

Tested by compiling library with uclibc. Without this patch, the
compilation fails along with an error for undefined bswap_{32,64}.
With this patch, it succeeds.